### PR TITLE
Large events no longer sent as a collection of individual fields

### DIFF
--- a/src/riemann_manifold/core.clj
+++ b/src/riemann_manifold/core.clj
@@ -47,7 +47,7 @@
   (send! [m c] [c m t]))
 
 (extend-protocol RiemannSender
-  clojure.lang.PersistentArrayMap
+  clojure.lang.IPersistentMap
   (send!
     ([m c] (send! m c 1000))
     ([m c t] (deref (r/send-event c m) t nil)))


### PR DESCRIPTION
Use IPersistentMap rather than a concrete type to handle the change
at PersistentArrayMap.HASHTABLE_THRESHOLD where the concrete type turns
from a PersistentArrayMap into a PersistentHashMap.
